### PR TITLE
Replace -printf for -print

### DIFF
--- a/pepper/rc/default_macos.pepper
+++ b/pepper/rc/default_macos.pepper
@@ -1,6 +1,6 @@
 copy-command "pbcopy"
 paste-command "pbpaste"
 
-map-normal <space>o [[: find-file "find . -type f -printf '%P\n'"<enter>]]
+map-normal <space>o [[: find-file "find . -type f -print"<enter>]]
 map-normal <space>f [[: find-pattern 'grep --recursive --binary-files=without-match --with-filename --line-number "{}"'<enter>]]
 


### PR DESCRIPTION
The BSD version of find (which macOS uses) does not support -printf.