### PR TITLE
track the presence of an empty line before EOF

### DIFF
--- a/pepper/src/buffer.rs
+++ b/pepper/src/buffer.rs
@@ -754,9 +754,11 @@ impl BufferContent {
     }
 
     pub fn write(&self, write: &mut dyn io::Write) -> io::Result<()> {
-        for line in &self.lines {
+        let end_index = self.lines.len() - 1;
+        for line in &self.lines[..end_index] {
             write!(write, "{}\n", line.as_str())?;
         }
+        write!(write, "{}", self.lines[end_index].as_str())?;
         Ok(())
     }
 


### PR DESCRIPTION
potentially a fix for #70. i think this provides a consistent user interface for buffers that end in newlines, buffers that end in non-newlines, and empty buffers being given a line to start with.