### PR TITLE
Fix typos in pepper

### DIFF
--- a/pepper/rc/bindings.md
+++ b/pepper/rc/bindings.md
@@ -76,7 +76,7 @@ It's also from where you do most of code navigation and seleciton manipulation.
 | `cd` | remove main cursor if there's more than one cursor |
 | `cD`, `CD` | clear all extra cursors and keep only the main cursor |
 | `cl` | splits all selection in lines |
-| `cj`, `ck` | add a new cursor to the line bellow/above the bottom/top cursor |
+| `cj`, `ck` | add a new cursor to the line below/above the bottom/top cursor |
 | `cn`, `cp` | set next/previous cursor as main cursor |
 | `cs` | search inside selections and only keep those ranges |
 | `cS`, `CS` | search inside selections and remove those ranges |
@@ -106,8 +106,8 @@ It's also from where you do most of code navigation and seleciton manipulation.
 | --- | --- | --- |
 | `I`, `<c-i>` | `dgii`, `dgli` | move cursors to first non-blank/last column and enter insert mode |
 | `ci` | `cvcCglccgii` | delete all lines touching a selection and enter insert mode |
-| `o`, `O` | `dgli<enter>`, `dgii<enter><up>` | create an empty line bellow/above each cursor and enter insert mode |
-| `J` | `djgivkgli<space><esc>` | join one line bellow each cursor |
+| `o`, `O` | `dgli<enter>`, `dgii<enter><up>` | create an empty line below/above each cursor and enter insert mode |
+| `J` | `djgivkgli<space><esc>` | join one line below each cursor |
 | `!` | `:<space>-spawn<enter>` | execute a command line (with closed stdin and ignoring its output) |
 | <code>&#124;</code> | `:<space>-replace-with-output<enter>` | pass each selection as stdin to a command line and substitute each for its stdout |
 

--- a/pepper/rc/changelog.md
+++ b/pepper/rc/changelog.md
@@ -10,7 +10,7 @@
 
 # 0.31.0
 - changed `plugin-remedybg` to add support for new version `0.3.8.4` which enables several plugin code simplifications
-- fix buffer insert processes would sometimes insert lines ending with a sigle `\r` which would screw some buffer invariants
+- fix buffer insert processes would sometimes insert lines ending with a single `\r` which would screw some buffer invariants
 - added support for msvc style path + line parsing
 - added `<` and `>` as path delimiters when using `gf`
 - fix "flickering" on unix caused by a forgotten `eprintln` in its platform layer
@@ -63,7 +63,7 @@
 # 0.29.0
 - added diagnostic logging to `spawn` command
 - added diagnostic logging to `replace-with-output` command
-- fix pattern bad optimization outupt when nonascii codepoints
+- fix pattern bad optimization output when nonascii codepoints
 - fix `remedybg-plugin` breakpoint sync on spawn
 - changed default value of `indent_with_tabs` to false
 - removed `xa` binding that used to list all breakpoints in a buffer
@@ -114,7 +114,7 @@
 - fix `gf` (and `GF`) that could open a duplicate of an already opened buffer if trying to open the same path but absolute
 - fix `reopen-all` would fail if there was a scratch buffer with a path that does not exist
 - changed `spawn` command to use a piped stdout in order to detect when the process exits
-- changed `cursor-<anchor/position>-<column/line>` expansions to be one based (instead of zero based) for easier interoperability with other softwares
+- changed `cursor-<anchor/position>-<column/line>` expansions to be one based (instead of zero based) for easier interoperability with other software
 
 ## 0.26.1
 - improved `find_path_and_position_at` to account for paths followed by `:`

--- a/pepper/rc/command_reference.md
+++ b/pepper/rc/command_reference.md
@@ -40,7 +40,7 @@ With '!' will discard any unsaved changes.
 - default alias: `qa`
 
 ## `open`
-Opens buffer up for editting.
+Opens buffer up for editing.
 If file `<path>` exists, it will be loaded into the buffer's content.
 Also, if `<path>` ends with `:<line>[,<column>]`, it will be opened at that location.
 

--- a/pepper/rc/config_recipes.md
+++ b/pepper/rc/config_recipes.md
@@ -19,7 +19,7 @@ put inside the `.pepper` file in your home directory.
 This way you're in control over from where pepper fetches its config files.
 
 ### per project config
-It's also posssible to setup configs that are per project.
+It's also possible to setup configs that are per project.
 Place a config file (`.pepper` in this example) in the root directory of your project then change your alias like this:
 
 ```

--- a/pepper/rc/expansion_reference.md
+++ b/pepper/rc/expansion_reference.md
@@ -11,7 +11,7 @@ That is: `@"..."`, `@'...'` or `@{...}`.
 # expansions
 
 ## `arg`
-When used inside a command declared using the `command` command, expands to the `<index>`th argument it received whell called.
+When used inside a command declared using the `command` command, expands to the `<index>`th argument it received when called.
 If instead of a zero-based index, its argument is `!`, it expands to `!` if the command was called with a bang
 (that is, `command! ...`) and to ` ` (empty) otherwise.
 Also, this expansion's argument can be `*` which will make it expand to all arguments passed to the called command.
@@ -123,5 +123,5 @@ If there is no such environment variable, it results in an empty expansion.
 
 ## `output`
 The stdout of external `<command>` (spawned with stdin closed).
-Will result in an emtpy expansion if the command fails.
+Will result in an empty expansion if the command fails.
 - usage: `@output(<command>)`

--- a/pepper/src/platforms/windows.rs
+++ b/pepper/src/platforms/windows.rs
@@ -924,7 +924,7 @@ impl ConnectionToClientListener {
         let mut reader = AsyncIO::new(handle.0);
 
         if unsafe { ConnectNamedPipe(handle.0, reader.overlapped().as_mut_ptr()) } != FALSE {
-            panic!("could not accept incomming connection");
+            panic!("could not accept incoming connection");
         }
 
         reader.pending_io = match get_last_error() {
@@ -933,7 +933,7 @@ impl ConnectionToClientListener {
                 reader.event.notify();
                 false
             }
-            _ => panic!("could not accept incomming connection"),
+            _ => panic!("could not accept incoming connection"),
         };
         reader.overlapped = Overlapped::with_event(reader.event());
 


### PR DESCRIPTION
Found via `codespell -L crate,writter,inout`